### PR TITLE
Add Dash links

### DIFF
--- a/appledoc_templates/html/document-template.html
+++ b/appledoc_templates/html/document-template.html
@@ -52,7 +52,7 @@
      
         <div id="dropdown">
           <div id="dash" style="display:none;">
-            <p>Click to add to Dash</p>
+            <p>Click to add to <a href="http://kapeli.com/dash">Dash</a></p>
           </div>
           <div id="xcode" style="display:none;">
             <p>Copy &amp; Paste into Xcode's Prefs</p>

--- a/appledoc_templates/html/hierarchy-template.html
+++ b/appledoc_templates/html/hierarchy-template.html
@@ -47,7 +47,7 @@
      
         <div id="dropdown">
           <div id="dash" style="display:none;">
-            <p>Click to add to Dash</p>
+            <p>Click to add to <a href="http://kapeli.com/dash">Dash</a></p>
           </div>
           <div id="xcode" style="display:none;">
             <p>Copy &amp; Paste into Xcode's Prefs</p>

--- a/appledoc_templates/html/index-template.html
+++ b/appledoc_templates/html/index-template.html
@@ -51,7 +51,7 @@
      
         <div id="dropdown">
           <div id="dash" style="display:none;">
-            <p>Click to add to Dash</p>
+            <p>Click to add to <a href="http://kapeli.com/dash">Dash</a></p>
           </div>
           <div id="xcode" style="display:none;">
             <p>Copy &amp; Paste into Xcode's Prefs</p>

--- a/appledoc_templates/html/object-template.html
+++ b/appledoc_templates/html/object-template.html
@@ -52,7 +52,7 @@
      
         <div id="dropdown">
           <div id="dash" style="display:none;">
-            <p>Click to add to Dash</p>
+            <p>Click to add to <a href="http://kapeli.com/dash">Dash</a></p>
           </div>
           <div id="xcode" style="display:none;">
             <p>Copy &amp; Paste into Xcode's Prefs</p>

--- a/public/fake_index.html
+++ b/public/fake_index.html
@@ -50,7 +50,7 @@
        
         <div id="dropdown">
           <div id="dash" style="display:none;">
-            <p>Click to add to Dash</p>
+            <p>Click to add to <a href="http://kapeli.com/dash">Dash</a></p>
           </div>
           <div id="xcode" style="display:none;">
             <p>Copy &amp; Paste into Xcode's Prefs</p>


### PR DESCRIPTION
Just a minor change - adds links to http://kapeli.com/dash to the "Click to add to Dash" popover. Not sure how well this fits to your future plans, but for now I think it's better this way as most users might not know about Dash.
