### PR TITLE
Add support for installing docsets into Xcode 5.

### DIFF
--- a/appledoc_templates/html/document-template.html
+++ b/appledoc_templates/html/document-template.html
@@ -58,7 +58,8 @@
             <p class="subtext"><a href="http://kapeli.com/dash">What is Dash?</a></p>
           </div>
           <div id="xcode" style="display:none;">
-            <p>Copy &amp; Paste into Xcode's Prefs</p>
+            <p>Click to <a href="docs-for-xcode://http%3A%2F%2Fcocoadocs.org%2Fdocsets%2F{{projectName}}%2Fxcode-docset.atom">add to Xcode</a> (via <a href="http://documancer.com/xcode/">Docs for Xcode</a>)</p>
+            <p>Or Copy &amp; Paste into Xcode 4's Prefs</p>
             <input readonly id="xcode_input" value="http://cocoadocs.org/docsets/{{projectName}}/xcode-docset.atom"></input>
           </div>
         </div>

--- a/appledoc_templates/html/hierarchy-template.html
+++ b/appledoc_templates/html/hierarchy-template.html
@@ -53,7 +53,8 @@
             <p class="subtext"><a href="http://kapeli.com/dash">What is Dash?</a></p>
           </div>
           <div id="xcode" style="display:none;">
-            <p>Copy &amp; Paste into Xcode's Prefs</p>
+            <p>Click to <a href="docs-for-xcode://http%3A%2F%2Fcocoadocs.org%2Fdocsets%2F{{projectName}}%2Fxcode-docset.atom">add to Xcode</a> (via <a href="http://documancer.com/xcode/">Docs for Xcode</a>)</p>
+            <p>Or Copy &amp; Paste into Xcode 4's Prefs</p>
             <input readonly id="xcode_input" value="http://cocoadocs.org/docsets/{{projectName}}/xcode-docset.atom"></input>
           </div>
         </div>

--- a/appledoc_templates/html/index-template.html
+++ b/appledoc_templates/html/index-template.html
@@ -58,7 +58,8 @@
             <p class="subtext"><a href="http://kapeli.com/dash">What is Dash?</a></p>
           </div>
           <div id="xcode" style="display:none;">
-            <p>Copy &amp; Paste into Xcode's Prefs</p>
+            <p>Click to <a href="docs-for-xcode://http%3A%2F%2Fcocoadocs.org%2Fdocsets%2F{{projectName}}%2Fxcode-docset.atom">add to Xcode</a> (via <a href="http://documancer.com/xcode/">Docs for Xcode</a>)</p>
+            <p>Or Copy &amp; Paste into Xcode 4's Prefs</p>
             <input readonly id="xcode_input" value="http://cocoadocs.org/docsets/{{projectName}}/xcode-docset.atom"></input>
           </div>
         </div>

--- a/appledoc_templates/html/object-template.html
+++ b/appledoc_templates/html/object-template.html
@@ -57,7 +57,8 @@
             <p class="subtext"><a href="http://kapeli.com/dash">What is Dash?</a></p>
           </div>
           <div id="xcode" style="display:none;">
-            <p>Copy &amp; Paste into Xcode's Prefs</p>
+            <p>Click to <a href="docs-for-xcode://http%3A%2F%2Fcocoadocs.org%2Fdocsets%2F{{projectName}}%2Fxcode-docset.atom">add to Xcode</a> (via <a href="http://documancer.com/xcode/">Docs for Xcode</a>)</p>
+            <p>Or Copy &amp; Paste into Xcode 4's Prefs</p>
             <input readonly id="xcode_input" value="http://cocoadocs.org/docsets/{{projectName}}/xcode-docset.atom"></input>
           </div>
         </div>

--- a/public/fake_index.html
+++ b/public/fake_index.html
@@ -53,7 +53,8 @@
             <p>Click to add to <a href="http://kapeli.com/dash">Dash</a></p>
           </div>
           <div id="xcode" style="display:none;">
-            <p>Copy &amp; Paste into Xcode's Prefs</p>
+            <p>Click to <a href="docs-for-xcode://http%3A%2F%2Fcocoadocs.org%2Fdocsets%2FRoutable%2Fxcode-docset.atom">add to Xcode</a> (via <a href="http://documancer.com/xcode/">Docs for Xcode</a>)</p>
+            <p>Or Copy &amp; Paste into Xcode 4's Prefs</p>
             <input readonly value="http://cocoadocs.org/docsets/Routable/xcode-docset.atom"></input>
           </div>
         </div>


### PR DESCRIPTION
As you know, Xcode 5 won't have UI for adding docsets, so the instructions in docset page's Xcode button, to "Copy & Paste into Xcode's Prefs", won't work anymore. This pull request addresses that.

I wrote a small (and free, of course) application to deal with this, [Docs for Xcode](http://documancer.com/xcode/). It has a custom `docs-for-xcode://` protocol for adding feeds, so it's possible to make installation of docsets as seamless as with Dash. This patch adds a link to cocoadocs.org's Xcode popup very similar to the existing Dash support:

![xcode_popup](https://f.cloud.github.com/assets/145881/1132549/eb3c060a-1bcc-11e3-8a4a-c9894ed3d845.png)

(I thought it would be better to keep existing UI for Xcode 4, even thought the app works with it as well.)
