### PR TITLE
Fix an issue where headers were not being included if they were for a platform

### DIFF
--- a/classes/docset_generator.rb
+++ b/classes/docset_generator.rb
@@ -79,20 +79,19 @@ class DocsetGenerator
 
     # https://github.com/CocoaPods/cocoadocs.org/issues/35
     [@spec, *@spec.subspecs].each do |internal_spec|
+      internal_spec.available_platforms.each do |platform|
+        consumer = Pod::Specification::Consumer.new(internal_spec, platform)
+        accessor = Pod::Sandbox::FileAccessor.new(pathlist, consumer)
 
-      if internal_spec.attributes_hash["source_files"]
-        internal_spec.available_platforms.each do |platform|
-          consumer = Pod::Specification::Consumer.new(internal_spec, platform)
-          accessor = Pod::Sandbox::FileAccessor.new(pathlist, consumer)
-          
+        if accessor.public_headers
           headers += accessor.public_headers.map{ |filepath| filepath.to_s }
+        else
+          puts "Skipping headers for #{internal_spec} on platform #{platform} (no headers found).".blue
         end
-      else
-        puts "Skipping headers for #{internal_spec}".blue
       end
     end
 
     headers.uniq
   end
-  
 end
+


### PR DESCRIPTION
This is when the headers are set for just a platform, they were being excluded
because the if statement to include all public headers was actually checking
something else (source_files).

This would also produce another bug if there was only private headers in a spec
or if there was only implementation files.
