### PR TITLE
Put code coverage into appledoc header

### DIFF
--- a/classes/docset_fixer.rb
+++ b/classes/docset_fixer.rb
@@ -59,14 +59,18 @@ class DocsetFixer
 
     project = @spec.source[:git].gsub(/(http(s)?:\/\/)?(github.com\/)?(.*?)(.git)?/, '\4')
 
-    coveralls_uri = URI("https://img.shields.io/coveralls/#{project}.svg")
-    coverage_svg = REXML::Document.new(Net::HTTP.get(coveralls_uri))
+    coveralls_uri = URI("https://coveralls.io/r/#{project}.json")
 
-    texts = coverage_svg.get_elements('svg/g/text').map { |text| text.get_text.to_s }
-    texts = texts.uniq.select { |text| text.end_with? '%' }
+    begin
+      coveralls_info = JSON.parse(Net::HTTP.get(coveralls_uri))
+      coverage_percentage = coveralls_info['model']['coverage_cache']['master']
 
-    @coverage_percent = texts.first
-    texts.first
+      @coverage_percent = "#{coverage_percentage}%"
+    rescue Exception => e
+      @coverage_percent = '0%'
+    end
+
+    @coverage_percent
   end
 
   def get_doc_percent

--- a/views/appledoc_template/_header.html
+++ b/views/appledoc_template/_header.html
@@ -105,6 +105,7 @@
       <% end %>
 
       <li class="no-link"><span class="subtitle">Documented</span><span="title">$$$DOC_PERCENT$$$%</span></li>
+      <li class="no-link"><span class="subtitle">Code Coverage</span><span="title">$$$COVERAGE_PERCENT$$$</span></li>
       <li class=""><a href="<%= spec.or_license_name_and_url[:url] %>"><span class="subtitle">License</span><%= spec.or_license_name_and_url[:license] %></a></li>
 
     </ul>


### PR DESCRIPTION
![](http://blog.millermedeiros.com/wp-content/uploads/2013/12/I-have-no-idea-what-I-am-doing.jpg)

This fetches the stats from Coveralls and shoehorns them into the appledoc header. Will probably break horribly for non-GH repos and if there's no actual coverage data there, but it's a start :)