### PR TITLE
Fixed crash when working directory has spaces

### DIFF
--- a/cocoadocs.rb
+++ b/cocoadocs.rb
@@ -314,9 +314,9 @@ class CocoaDocs < Object
     unless File.exists? repo
       vputs "Creating Specs Repo for #{$specs_repo}"
       unless repo.include? "://"
-        command "git clone git://github.com/#{$specs_repo}.git #{repo} --depth 1"
+        command "git clone git://github.com/#{$specs_repo}.git \"#{repo}\" --depth 1"
       else
-        command "git clone #{$specs_repo} #{repo} --depth 1"
+        command "git clone \"#{$specs_repo}\" \"#{repo}\" --depth 1"
       end
     else
       if $fetch_specs


### PR DESCRIPTION
This is a fix for issue #191. I added quotes around a few of the arguments in the calls to `git`. They definitely fixed the error I was experiencing, and should do no harm, though the other invocation of git should be tested as well. I didn't test that case.
