### PR TITLE
Made cocoadocs script more easily re-runnable by dropping the download directory if it already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ errors
 error_log.txt
 .sass-cache/
 .env
+.DS_Store

--- a/classes/appledoc_template_generator.rb
+++ b/classes/appledoc_template_generator.rb
@@ -39,11 +39,13 @@ class AppledocTemplateGenerator
     Dir[Dir.pwd + "/views/appledoc_template/*.html.erb"].each do |file|
       filename = File.basename(file, ".html.erb")
       output = render_erb file
-      output_path = @appledoc_templates_path + "/html/" + filename + ".html"
-      File.open(output_path, 'w') { |f| f.write output }
+      output_path = File.join(@appledoc_templates_path, "html")
+      FileUtils.mkpath(output_path) if !File.directory?(output_path)
+      output_file = File.join(output_path, filename + ".html")
+      File.open(output_file, 'w') { |f| f.write output }
     end
 
-    `cp -r #{Dir.pwd}/views/docset #{@appledoc_templates_path}`
+    `cp -r \"#{Dir.pwd}\"/views/docset \"#{@appledoc_templates_path}\"`
   end
 
   # ERB helpers

--- a/classes/docset_fixer.rb
+++ b/classes/docset_fixer.rb
@@ -69,13 +69,13 @@ class DocsetFixer
     return unless Dir.exists? @docset_path + "html/"
 
     vputs "Moving /POD/version/html/index.html to /POD/version/index.html"
-    command "cp -Rf #{@docset_path}html/* #{@docset_path}/"
-    command "rm -Rf #{@docset_path}/html"
+    command "cp -Rf \"#{@docset_path}\"html/* \"#{@docset_path}/\""
+    command "rm -Rf \"#{@docset_path}\"/html"
   end
 
   def delete_extra_docset_folder
     vputs "Removing redundant docset extracts"
-    command "rm -Rf #{@docset_path}/docset"
+    command "rm -Rf \"#{@docset_path}\"/docset"
   end
 
   def fix_relative_link link_string
@@ -114,7 +114,7 @@ class DocsetFixer
       end
     end
 
-    `rm #{@readme_path}`
+    `rm \"#{@readme_path}\"`
     File.open(@readme_path, 'w') { |f| f.write(doc) }
   end
 
@@ -144,7 +144,7 @@ class DocsetFixer
       end
     end
 
-    `rm #{@readme_path}`
+    `rm \"#{@readme_path}\"`
     File.open(@readme_path, 'w') { |f| f.write(doc) }
   end
 
@@ -164,14 +164,14 @@ class DocsetFixer
       end
     end
 
-    `rm #{@readme_path}`
+    `rm \"#{@readme_path}\"`
     File.open(@readme_path, 'w') { |f| f.write(doc) }
   end
 
   def move_docset_icon_in
     vputs "Adding Docset Icon For Dash"
     docset = "com.cocoadocs.#{@spec.name.downcase}.#{@spec.name}.docset"
-    command "cp resources/docset_icon.png #{@docset_path}/#{docset}/icon.png"
+    command "cp resources/docset_icon.png \"#{@docset_path}\"/#{docset}/icon.png"
   end
 
   def move_gfm_readme_in
@@ -196,12 +196,12 @@ class DocsetFixer
     docset = "com.cocoadocs.#{@spec.name.downcase}.#{@spec.name}.docset"
 
     # embed css in docset
-    command "sass views/appledoc_stylesheet.scss:#{@docset_path}/#{docset}/Contents/Resources/Documents/appledoc_stylesheet.css"
-    command "sass views/appledoc_gfm.scss:#{@docset_path}/#{docset}/Contents/Resources/Documents/appledoc_gfm.css"
+    command "sass views/appledoc_stylesheet.scss:\"#{@docset_path}\"/#{docset}/Contents/Resources/Documents/appledoc_stylesheet.css"
+    command "sass views/appledoc_gfm.scss:\"#{@docset_path}\"/#{docset}/Contents/Resources/Documents/appledoc_gfm.css"
 
     # copy to website too
-    command "cp #{@docset_path}/#{docset}/Contents/Resources/Documents/appledoc_stylesheet.css #{@docset_path}/"
-    command "cp #{@docset_path}/#{docset}/Contents/Resources/Documents/appledoc_gfm.css #{@docset_path}/"
+    command "cp \"#{@docset_path}\"/#{docset}/Contents/Resources/Documents/appledoc_stylesheet.css \"#{@docset_path}/\""
+    command "cp \"#{@docset_path}\"/#{docset}/Contents/Resources/Documents/appledoc_gfm.css \"#{@docset_path}/\""
 
   end
 

--- a/classes/docset_generator.rb
+++ b/classes/docset_generator.rb
@@ -21,6 +21,8 @@ class DocsetGenerator
 
     template_directory = File.join($current_dir, 'appledoc_templates')
 
+    FileUtils.mkpath(to) if !File.directory?(to)
+
     docset_command = [
       "appledoc",
       "--project-name #{@spec.name}",                           # name in top left
@@ -30,7 +32,7 @@ class DocsetGenerator
       "--project-version #{version}",                           # project version
       "--no-install-docset",                                    # don't make a duplicate
 
-      "--templates #{@appledoc_templates_path}",                # use the custom template
+      "--templates \"#{@appledoc_templates_path}\"",            # use the custom template
       "--verbose #{verbosity}",                                 # give some useful logs
 
       "--keep-intermediate-files",                              # space for now is OK
@@ -53,7 +55,7 @@ class DocsetGenerator
 
       guides.generate_string_for_appledoc,
 
-      "--output #{@to}",                                      # where should we throw stuff
+      "--output \"#{@to}\"",                                      # where should we throw stuff
       *headers
     ]
 
@@ -66,7 +68,7 @@ class DocsetGenerator
     raise "Appledoc crashed in creating the DocSet for this project." unless Dir.exists? to
 
     # Appledoc did not generate HTML for this project. Perhaps it has no objc classes?
-    index = to + "/html/index.html"
+    index = File.join(to, "html", "index.html")
     unless File.exists? index
       show_error_page index, "Could not find Objective-C Classes."
     end
@@ -76,7 +78,7 @@ class DocsetGenerator
   def show_error_page path, error
     vputs "Got an error from Appledoc"
 
-    index_template_path = @appledoc_templates_path + "/html/index-template.html"
+    index_template_path = File.join(@appledoc_templates_path, "html", "index-template.html")
     metadata = {
         :page => {
           :title => @spec.name
@@ -95,6 +97,8 @@ class DocsetGenerator
     fake_index_content = File.read("resources/overwritten_index.html")
 
     index_content = index_content.gsub('index-overview">', 'index-overview">' + fake_index_content)
+    output_path = File.dirname(path)
+    FileUtils.mkpath(output_path) if !File.directory?(output_path)
     File.open(path, 'w') { |f| f.write(index_content) }
   end
 

--- a/classes/website_generator.rb
+++ b/classes/website_generator.rb
@@ -11,9 +11,9 @@ class WebsiteGenerator
   def move_public_items
     resources_dir = "#{$active_folder}/html/assets/"
 
-    command "rm -rf #{resources_dir}"
-    command "mkdir #{resources_dir}"
-    command "cp -R public/* #{resources_dir}"
+    command "rm -rf \"#{resources_dir}\""
+    command "mkdir \"#{resources_dir}\""
+    command "cp -R public/* \"#{resources_dir}\""
   end
 
   def upload_docset

--- a/cocoadocs.rb
+++ b/cocoadocs.rb
@@ -228,15 +228,15 @@ class CocoaDocs < Object
 
     if Dir.exists? spec_path  + name
       version = Dir.entries(spec_path + name).last
-      spec_path = "#{spec_path + name}/#{version}/#{name}.podspec.json"
+      spec_path = File.join("#{spec_path}","#{name}", "#{version}", "#{name}.podspec.json")
 
       $overwrite_existing_source_files = true
       $delete_source_after_docset_creation = false
       $force_master = true
 
       document_spec_at_path spec_path
-      command "open #{ $active_folder }/docsets/#{ name }/#{ version }/"
-      puts "Preview: #{ $active_folder }/docsets/#{ name }/#{ version }/"
+      command "open \"#{ $active_folder }\"/docsets/#{ name }/#{ version }/"
+      puts "Preview: \"#{ $active_folder }\"/docsets/#{ name }/#{ version }/"
     else
       puts "Could not find spec at " + spec_path + name
     end
@@ -405,8 +405,8 @@ class CocoaDocs < Object
 
       if $delete_source_after_docset_creation
         vputs "Deleting source files"
-        command "rm -rf #{download_location}"
-        command "rm -rf #{docset_location}" if $upload_site_to_s3
+        command "rm -rf \"#{download_location}\""
+        command "rm -rf \"#{docset_location}\"" if $upload_site_to_s3
       end
 
       state = "success"

--- a/webpages.rb
+++ b/webpages.rb
@@ -26,7 +26,7 @@ end
 
 def copy_folder from, to
   command "mkdir -p #{ @prefix }/#{to}"
-  command "cp -R #{ @prefix }/#{from}/* #{ @prefix }/#{to}"
+  command "cp -R \"#{ @prefix }/#{from}\"/* \"#{ @prefix }/#{to}\""
 end
 
 save_slim "views/404.slim", "activity/website/404.html"


### PR DESCRIPTION
This may not be the "right" place to do this, but it definitely gets the job done (Issue #260)
