### PR TITLE
[appledoc] Shell escape headers and output

### DIFF
--- a/classes/docset_generator.rb
+++ b/classes/docset_generator.rb
@@ -1,3 +1,5 @@
+require 'shellescape'
+
 class DocsetGenerator
   include HashInit
   attr_accessor :spec, :from, :to, :readme_location, :appledoc_templates_path, :library_settings, :source_download_location
@@ -52,8 +54,8 @@ class DocsetGenerator
 
       *guides.generate_array_for_appledoc,
 
-      "--output", to,                                        # where should we throw stuff
-      *headers
+      "--output", to.shellescape,                            # where should we throw stuff
+      *headers.map { |header| header.shellescape }
     ]
 
     if File.exist? readme_location


### PR DESCRIPTION
I'm sure I fixed this before? Have we had this bug all along or has it been reintroduced? /c @orta @segiddins 

Closes #306

Also note: Didn't test this manually and we have no test coverage.