### PR TITLE
Decouple measurement from data sending.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: ./server.rb
-web_ping: while true; do ruby ping.rb; sleep 300; done
+web_ping: ./ping.rb

--- a/ping.rb
+++ b/ping.rb
@@ -2,24 +2,58 @@
 
 require 'rubygems'
 require 'httparty'
-require 'timeout'
 
-begin
-  number = HTTParty.get "http://localhost:4567/recent_pods_count"
-  puts "Sending #{number} pods to Status.io"
+api_key = ENV['STATUS_IO_API_KEY']
+page_id = ENV['STATUS_IO_PAGE_ID']
+metric_id = ENV['STATUS_IO_METRIC_ID']
+api_base = 'https://api.statuspage.io/v1'
 
-  api_key = ENV['STATUS_IO_API_KEY']
-  page_id = ENV['STATUS_IO_PAGE_ID']
-  metric_id = ENV['STATUS_IO_METRIC_ID']
-  api_base = 'https://api.statuspage.io/v1'
+interval = 60 * 5.0
 
-  dhash = {
-    :timestamp => Time.now.to_i,
-    :value => number.to_i
-  }
+numbers = Hash.new { 0 }
 
-  HTTParty.post("#{api_base}/pages/#{page_id}/metrics/#{metric_id}/data.json",  :headers => { 'Authorization' => "OAuth #{api_key}" }, :body => { :data => dhash } )
+# Returns the same time for all times in a 5 minute interval.
+#
+def slot_for current_seconds, interval
+  (current_seconds / interval).floor * interval
+end
 
-  sleep 1
-rescue
+loop do
+  begin
+    # Remember current time.
+    #
+    current_seconds = Time.now.to_i
+    
+    # Get current count.
+    #
+    number = HTTParty.get "http://cocoadocs.org/recent_pods_count"
+    
+    # Find slot for count and add.
+    #
+    slot = slot_for current_seconds, interval
+    numbers[slot] += number
+
+    # If a time slot is finished.
+    #
+    while numbers.size > 1
+      # Remove the one that's finished.
+      #
+      time, value = numbers.shift
+
+      puts "Sending #{value} pods to statuspage.io."
+
+      data = {
+        :timestamp => time,
+        :value => value
+      }
+      
+      # And send to statuspage.io.
+      #
+      HTTParty.post("#{api_base}/pages/#{page_id}/metrics/#{metric_id}/data.json",  :headers => { 'Authorization' => "OAuth #{api_key}" }, :body => { :data => data } )
+    end
+  rescue StandardError => e
+    puts e
+  end
+
+  sleep interval / 5
 end


### PR DESCRIPTION
I've decoupled the measuring of pods from sending it to statuspage.io.

This should remove any gaps in the graph.