### PR TITLE
[Test Expectations] Count XCTFail

### DIFF
--- a/classes/testing_idealist.rb
+++ b/classes/testing_idealist.rb
@@ -65,7 +65,7 @@ class TestingIdealist
     # Kiwi: should]
     # XCTest: XCTAssert
     
-    expectation_count = ["expect(", "should]", "assertThat", "XCTAssert"].map do |expectation|
+    expectation_count = ["expect(", "should]", "assertThat", "XCTAssert", "XCTFail"].map do |expectation|
        content.split(expectation).length - 1
     end.sort.last
     


### PR DESCRIPTION
I'm using this in a bunch of tests, I think it makes use to include.

```swift
func assertFailure(result:DecodeResult, closure:(InvalidToken -> ())? = nil) {
  switch result {
  case .Success(let payload):
    XCTFail("Decoded when expecting a failure.")
  case .Failure(let failure):
    if let closure = closure {
      closure(failure)
    }
    break
  }
}
```