### PR TITLE
Ignore broken symlinks during project search

### DIFF
--- a/classes/testing_idealist.rb
+++ b/classes/testing_idealist.rb
@@ -14,6 +14,7 @@ class TestingIdealist
   def testimate
     
 		get_projects_in_download.reduce(0) do |expectations, project_path|
+      next 0 unless File.exist?(project_path)
       project = path_to_project project_path
       
       expectations + find_test_target(project).reduce(0) do |target_expectations, target|


### PR DESCRIPTION
Fix for:

> [Xcodeproj] Unable to open `/Users/maddern/dev/cocoadocs.org/activity/download/Stargate/0.1.0/Stargate/_Carthage.xcodeproj` because it doesn't exist.