### PR TITLE
[Testing Idealist] Improve expectation counting

### DIFF
--- a/classes/testing_idealist.rb
+++ b/classes/testing_idealist.rb
@@ -61,13 +61,16 @@ class TestingIdealist
       return has_no_tests
     end
     
-    # OCHamcrest: assertThat
-    # Specta + Quick: expect(
-    # Kiwi: should]
-    # XCTest: XCTAssert
+    regexes = [/XCTAssert|XCTFail/,        # XCTest
+               /expect\(/,                 # Expecta, Nimble
+               /should\]|shouldNot\]/,     # Kiwi
+               /assertThat/,               # OCHamcrest
+               / should .*;| should_not /, # Cedar
+               /FBSnapshotVerify/          # FBSnapshotTestCase
+             ]
     
-    expectation_count = ["expect(", "should]", "assertThat", "XCTAssert", "XCTFail"].map do |expectation|
-       content.split(expectation).length - 1
+    expectation_count = regexes.map do |expectation_regex|
+      content.scan(expectation_regex).length
     end.sort.last
     
    return has_no_tests if expectation_count == 0

--- a/spec/fixtures/specs/CedarSpec.mm
+++ b/spec/fixtures/specs/CedarSpec.mm
@@ -1,0 +1,17 @@
+#import <Cedar/Cedar.h>
+
+using namespace Cedar::Matchers;
+
+SPEC_BEGIN(CedarSpec)
+
+describe(@"Cedar Expectations", ^{
+    // Words in the comments should not contribute to the total count
+    it(@"should work", ^{
+        @"abc" should equal(@"abc");
+        @"str" should contain(@"s"); // This line has a comment
+        2 should_not equal(1);
+        NO should_not be_truthy;
+    });
+});
+
+SPEC_END

--- a/spec/fixtures/specs/ExpectaSpec.m
+++ b/spec/fixtures/specs/ExpectaSpec.m
@@ -1,0 +1,14 @@
+#import "Specta.h"
+#import <Expecta/Expecta.h>
+
+SpecBegin(Expecta)
+
+describe(@"Expecta Expectations", ^{
+    it(@"should work", ^{
+        expect(2).notTo.equal(1);
+        expect(@"abc").to.equal(@"abc");
+        expect([@"str" containsString"s"]).to.equal(YES);
+    });
+});
+
+SpecEnd

--- a/spec/fixtures/specs/FBSnapshotTests.m
+++ b/spec/fixtures/specs/FBSnapshotTests.m
@@ -1,0 +1,14 @@
+#import <XCTest/XCTest.h>
+#import <FBSnapshotTestCase/FBSnapshotTestCase.h>
+
+@interface FBSnapshotTests : FBSnapshotTestCase
+@end
+
+@implementation FBSnapshotTests
+
+- (void)testVerification {
+    FBSnapshotVerifyView([[UIView alloc] init], nil);
+    FBSnapshotVerifyLayer([[CALayer alloc] init], nil);
+}
+
+@end

--- a/spec/fixtures/specs/KiwiSpec.m
+++ b/spec/fixtures/specs/KiwiSpec.m
@@ -1,0 +1,13 @@
+#import <Kiwi/Kiwi.h>
+
+SPEC_BEGIN(KiwiSpec)
+
+describe(@"Kiwi Expectations", ^{
+    it(@"should work", ^{
+        [[@"a" shouldNot] beNil];
+        [[@"b" should] beKindOfClass:[NSString class]];
+        [[theValue([@"42" integerValue]) should] equal:theValue(42)];
+    });
+});
+
+SPEC_END

--- a/spec/fixtures/specs/NimbleSpec.swift
+++ b/spec/fixtures/specs/NimbleSpec.swift
@@ -1,0 +1,14 @@
+import Quick
+import Nimble
+
+class NimbleSpec: QuickSpec {
+    override func spec() {
+        describe("Nimble Expectations") {
+            it("should work") {
+                expect(1).toNot(equal(2))
+                expect("abc").to(equal("abc"))
+                expect("str").to(contain("s"))
+            }
+        }
+    }
+}

--- a/spec/fixtures/specs/OCHamcrest.m
+++ b/spec/fixtures/specs/OCHamcrest.m
@@ -1,0 +1,17 @@
+#import <XCTest/XCTest.h>
+
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
+
+@interface OCHamcrestTest : XCTestCase
+@end
+
+@implementation OCHamcrestTest
+
+- (void)testOne {
+    assertThat(@"abc", isNot(@"bcd"));
+    assertThat(@"str", containsString(@"s"));
+    assertThatInt(42, is(@42));
+}
+
+@end

--- a/spec/fixtures/specs/XCTest.m
+++ b/spec/fixtures/specs/XCTest.m
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+@interface ExampleTests : XCTestCase
+
+@end
+
+@implementation ExampleTests
+
+- (void)testOne {
+    XCTAssert(YES);
+    XCTAssertEqualObjects(@1, [NSNumber numberWithInteger:1]);
+}
+
+- (void)testFail {
+    XCTFail("No good");
+}
+
+@end

--- a/spec/testing_idealist_spec.rb
+++ b/spec/testing_idealist_spec.rb
@@ -1,0 +1,46 @@
+require File.expand_path('../spec_helper', __FILE__)
+require '_utils'
+require 'testing_idealist'
+
+describe 'Counting test expectations' do
+
+  def testingness_for file_path
+	tester = TestingIdealist.new()
+	tester.estimate_testingness_in_file file_path
+  end
+
+  it 'should properly count XCTest assertions' do
+    testingness = testingness_for "spec/fixtures/specs/XCTest.m"
+    testingness.should.equal ({ has_tests: true,  expectations: 3 })
+  end
+
+  it 'should properly count Specta expectations' do
+    testingness = testingness_for "spec/fixtures/specs/ExpectaSpec.m"
+    testingness.should.equal ({ has_tests: true,  expectations: 3 })
+  end
+
+  it 'should properly count Nimble expectations' do
+  	testingness = testingness_for "spec/fixtures/specs/NimbleSpec.swift"
+    testingness.should.equal ({ has_tests: true,  expectations: 3 })
+  end
+
+  it 'should properly count Kiwi expectations' do
+  	testingness = testingness_for "spec/fixtures/specs/KiwiSpec.m"
+    testingness.should.equal ({ has_tests: true,  expectations: 3 })
+  end
+
+  it 'should properly count Cedar expectations' do
+  	testingness = testingness_for "spec/fixtures/specs/CedarSpec.mm"
+    testingness.should.equal ({ has_tests: true,  expectations: 4 })
+  end
+
+  it 'should properly count OCHamcrest assertions' do
+    testingness = testingness_for "spec/fixtures/specs/OCHamcrest.m"
+    testingness.should.equal ({ has_tests: true,  expectations: 3 })
+  end
+
+  it 'should properly count FBSnapshotTestCase assertions' do
+  	testingness = testingness_for "spec/fixtures/specs/FBSnapshotTests.m"
+    testingness.should.equal ({ has_tests: true,  expectations: 2 })
+  end
+end


### PR DESCRIPTION
* Add specs for expectation counting
* Use regex matching for more flexibility
* Count Cedar and FBSnapshotTestCase
* Fix bugs with counting Kiwi and XCTest expectations