### PR TITLE
Additional expectation search improvements

### DIFF
--- a/classes/testing_idealist.rb
+++ b/classes/testing_idealist.rb
@@ -61,12 +61,12 @@ class TestingIdealist
       return has_no_tests
     end
     
-    regexes = [/XCTAssert|XCTFail/,        # XCTest
-               /expect\(/,                 # Expecta, Nimble
-               /should\]|shouldNot\]/,     # Kiwi
-               /assertThat/,               # OCHamcrest
-               / should .*;| should_not /, # Cedar
-               /FBSnapshotVerify/          # FBSnapshotTestCase
+    regexes = [/XCTAssert|XCTFail/,                 # XCTest
+               /expect\(/,                          # Expecta, Nimble
+               /should\]|shouldNot\]/,              # Kiwi
+               /assertThat/,                        # OCHamcrest
+               / should .*;| should_not |expect\(/, # Cedar
+               /FBSnapshotVerify/                   # FBSnapshotTestCase
              ]
     
     expectation_count = regexes.map do |expectation_regex|

--- a/classes/testing_idealist.rb
+++ b/classes/testing_idealist.rb
@@ -106,9 +106,11 @@ class TestingIdealist
       rescue
         next
       end
-      %w(bundle.ui-testing bundle.unit-test).any? do |testing_type|
+      is_test_bundle = %w(bundle.ui-testing bundle.unit-test).any? do |testing_type|
         product_type.end_with?(testing_type)
       end
+
+      is_test_bundle || target.name.downcase.scan(/specs|tests/).length > 0
     end
   end
 

--- a/classes/testing_idealist.rb
+++ b/classes/testing_idealist.rb
@@ -83,7 +83,7 @@ class TestingIdealist
       pbx_build_file.file_ref.real_path.to_s
       
     end.select do |path| 
-      path.end_with?(".m") || path.end_with?(".swift") 
+      path.end_with?(".m", ".mm", ".swift")
       
     end.select do |path| 
       File.exists? path

--- a/spec/fixtures/specs/CedarSpec.mm
+++ b/spec/fixtures/specs/CedarSpec.mm
@@ -11,6 +11,7 @@ describe(@"Cedar Expectations", ^{
         @"str" should contain(@"s"); // This line has a comment
         2 should_not equal(1);
         NO should_not be_truthy;
+        expect(@"cat").to_not(equal(@"dog")); // Alternate matcher syntax
     });
 });
 

--- a/spec/testing_idealist_spec.rb
+++ b/spec/testing_idealist_spec.rb
@@ -31,7 +31,7 @@ describe 'Counting test expectations' do
 
   it 'should properly count Cedar expectations' do
   	testingness = testingness_for "spec/fixtures/specs/CedarSpec.mm"
-    testingness.should.equal ({ has_tests: true,  expectations: 4 })
+    testingness.should.equal ({ has_tests: true,  expectations: 5 })
   end
 
   it 'should properly count OCHamcrest assertions' do


### PR DESCRIPTION
Here are some supplemental improvements to #377. For context, my goal is to get tests recognized for a number of libraries that I am involved with that are tested using [Cedar](https://github.com/pivotal/cedar). The additional changes here are:

* Include `.mm` (Objective-C++) files when looking for expectations
* Recognize Cedar's alternate `expect(...)` syntax
* When finding test targets, include those that aren't Xcode test bundles, but have `Tests` or `Specs` in their names. It is common for libraries tested with Cedar to structure standalone test suites like this when there is no sensible host app for a test bundle to attach to.

I have locally tested the stats generation for a few libraries (e.g. Cedar itself, [Blindside](https://github.com/jbsf/blindside)) with these changes, and am seeing the results I expect.