### PR TITLE
Fix show on GitHub images being blurry on retina screens

### DIFF
--- a/views/appledoc_template/object-template.html.erb
+++ b/views/appledoc_template/object-template.html.erb
@@ -188,7 +188,7 @@ Section Method
 <div class="section-method">
 	<a name="{{htmlReferenceName}}" title="{{methodSelector}}"></a>
 
-	<h3 class="subsubtitle method-title">{{methodSelector}} <span class="hover-only"><a href="<%= @spec.or_github_search_context_method %>"><img src="http://cocoadocs.org.s3.amazonaws.com/assets/img/blacktocat-16.png"></a></span></h3>
+	<h3 class="subsubtitle method-title">{{methodSelector}} <span class="hover-only"><a href="<%= @spec.or_github_search_context_method %>"><img src="http://cocoadocs.org.s3.amazonaws.com/assets/img/blacktocat-32.png" height=16 width=16></a></span></h3>
 
 	{{#comment}}
 	{{#hasShortDescription}}{{^hasLongDescription}}

--- a/views/appledoc_template/object-template.html.erb
+++ b/views/appledoc_template/object-template.html.erb
@@ -41,7 +41,7 @@
 
 				<div id="header">
 					<div class="section-header">
-						<h1 class="title title-header">{{page.title}} <span class="hover-only"><a href="<%= @spec.or_github_search_context_class %>https://github.com/search?q={{object.nameOfClass}}++extension%3Am&type=Code#{ @spec.or_github_search_context }&ref=searchresults"><img src="http://cocoadocs.org.s3.amazonaws.com/assets/img/blacktocat-32.png" height=32 height=32></a></span></h1>
+						<h1 class="title title-header">{{page.title}} <span class="hover-only"><a href="<%= @spec.or_github_search_context_class %>https://github.com/search?q={{object.nameOfClass}}++extension%3Am&type=Code#{ @spec.or_github_search_context }&ref=searchresults"><img src="http://cocoadocs.org.s3.amazonaws.com/assets/img/blacktocat-32.png" height=16 width=16></a></span></h1>
 					</div>
 				</div>
 


### PR DESCRIPTION
This PR changes the sizes of the “show on GitHub” blacktocat images shown to make them non-blurry on retina screens. It also makes the image after the class reference name header be less obtrusively large.

There’s also a small fix in here as the `height` property was duplicated for the class reference image.

**Screenshot of the changes, before :point_right: after:**

<img alt="Screenshot of the changes" src="https://cloud.githubusercontent.com/assets/23453/12499177/8c1fa2e8-c0a8-11e5-8207-226406b0494d.png" width=917>
_(Blurryness is easiest to notice if image is opened in a separate tab and zoomed to 100 %.)_