### PR TITLE
Support config files erroring in jazzy, and tell jazzy that we're setting the podspec

### DIFF
--- a/cocoadocs.rb
+++ b/cocoadocs.rb
@@ -428,9 +428,15 @@ class CocoaDocs < Object
 
         config = Jazzy::Config.new.tap do |c|
           c.config_file = Pathname(jazzy_config) if jazzy_config
-          c.parse_config_file
+          begin
+            c.parse_config_file
+          rescue => e
+            vputs "Setting up jazzy config failed: #{e.message.red} - continuing"
+          end
 
           c.podspec = Pod::Specification.from_file(download_spec_path)
+          c.podspec_configured = true
+
           c.output = Pathname(docset_location)
           c.min_acl = Jazzy::SourceDeclaration::AccessControlLevel.public
           c.docset_icon = Pathname(__FILE__).parent + 'resources/docset_icon.png'


### PR DESCRIPTION
I'm not really sure why, but setting podspec on the config isn't setting `podspec_configured` on the config object, and so Jazzy doesn't download dependencies and set up documentation. Now it does.

Deals with #424  Jazzy halting when a json podspec isn't found in the source when it has been defined in a jazzy config. This leaves space for a real solution where we whitelist the keys that won't break CD, so not "fixed" but fixed.