### PR TITLE
Updates Jazzy, and ensures that the module_name is set

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "cocoapods"
 gem "cocoapods-core"
 gem "cocoapods-downloader"
 
-gem 'jazzy', '~> 0.2'
+gem 'jazzy'
 
 gem "docstat"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5)
+    activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -74,7 +74,7 @@ GEM
       multi_json (~> 1.0)
       multi_xml
     i18n (0.7.0)
-    jazzy (0.5.0)
+    jazzy (0.6.0)
       cocoapods (~> 0.39)
       mustache (~> 0.99)
       open4
@@ -82,7 +82,7 @@ GEM
       rouge (~> 1.5)
       sass (~> 3.4)
       sqlite3 (~> 1.3)
-      xcinvoke (~> 0.2.0)
+      xcinvoke (~> 0.2.1)
     json (1.8.3)
     launchy (2.4.2)
       addressable (~> 2.3)
@@ -91,17 +91,17 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
-    minitest (5.8.3)
+    minitest (5.8.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
       mocha (>= 0.13.0)
-    molinillo (0.4.1)
+    molinillo (0.4.4)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     mustache (0.99.8)
-    nap (1.0.0)
+    nap (1.1.0)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
     net-ssh (2.9.2)
@@ -151,7 +151,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.6.0)
-    sass (3.4.20)
+    sass (3.4.22)
     sawyer (0.5.5)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -188,7 +188,7 @@ GEM
       json (~> 1.8.1)
       rest-client (~> 1.6.7)
     websocket (1.2.1)
-    xcinvoke (0.2.0)
+    xcinvoke (0.2.1)
       liferaft (~> 0.0.4)
     xcodeproj (0.28.2)
       activesupport (>= 3)
@@ -208,7 +208,7 @@ DEPENDENCIES
   foreman
   htmlcompressor
   httparty
-  jazzy (~> 0.2)
+  jazzy
   mocha
   mocha-on-bacon
   mustache

--- a/cocoadocs.rb
+++ b/cocoadocs.rb
@@ -94,19 +94,6 @@ class CocoaDocs < Object
 
   def initialize(args)
 
-    appledoc_version = `vendor/appledoc --version`.strip.gsub("appledoc version: ", "").split(" ")[0].to_f
-    if appledoc_version < 2.2
-      puts "You need an updated version of appledoc, grab the latest release: https://github.com/tomaz/appledoc/releases".red
-      exit
-    end
-
-    cloc_path = `which cloc`.strip.chomp
-    if cloc_path == ""
-      puts "You need an to install cloc".red
-      puts "run " + "brew install cloc".red
-      exit
-    end
-
     if ARGV.length > 0
       setup_options ARGV
 
@@ -443,6 +430,7 @@ class CocoaDocs < Object
           c.docset_path = "com.cocoadocs.#{spec.name.downcase}.#{spec.name}.docset"
           c.readme_path = Pathname(readme_location)
           c.source_directory = Pathname(download_location)
+          c.module_name = spec.name
           c.clean = true
           c.dash_url = "#{$website_home}docsets/#{spec.name}/#{spec.name}.xml"
         end

--- a/cocoadocs.rb
+++ b/cocoadocs.rb
@@ -430,7 +430,7 @@ class CocoaDocs < Object
           c.docset_path = "com.cocoadocs.#{spec.name.downcase}.#{spec.name}.docset"
           c.readme_path = Pathname(readme_location)
           c.source_directory = Pathname(download_location)
-          c.module_name = spec.name
+          c.module_name = spec.module_name
           c.clean = true
           c.dash_url = "#{$website_home}docsets/#{spec.name}/#{spec.name}.xml"
         end


### PR DESCRIPTION
Honestly, I don't really know why the module name isn't being passed through the podspec setup of the config file ( when I  read the code, it should be set ) but I'll take working vs "should be" - this fixes https://github.com/CocoaPods/cocoadocs.org/issues/430 

Also removes checks for vendored dependencies as they're now in the source. 

Waiting on #437 to push & update the Xcode o the server to deal with the new default of Xcode 7.3