### PR TITLE
Make test idealist aware of SwiftCheck

### DIFF
--- a/classes/testing_idealist.rb
+++ b/classes/testing_idealist.rb
@@ -72,7 +72,8 @@ class TestingIdealist
                /should\]|shouldNot\]/,              # Kiwi
                /assertThat/,                        # OCHamcrest
                / should .*;| should_not |expect\(/, # Cedar
-               /FBSnapshotVerify/                   # FBSnapshotTestCase
+               /FBSnapshotVerify/,                  # FBSnapshotTestCase
+               /property\(/                         # SwiftCheck
              ]
 
     expectation_count = regexes.map do |expectation_regex|


### PR DESCRIPTION
Makes the test metrics aware of suites that use [SwiftCheck](https://github.com/typelift/SwiftCheck) properties instead of more traditional expect/assert suites.  I'm not aware if the identifier `property` is used in these other testing suites, though my experience with most of them says checking for this call to our DSL shouldn't affect existing specs except, of course, if they're already using SwiftCheck.