### PR TITLE
Update to the CP beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,11 @@ ruby '2.1.3'
 
 gem 'rake'
 
-gem "cocoapods"
-gem "cocoapods-core"
+gem "cocoapods", "1.1.0.rc.3"
 gem "cocoapods-downloader"
+# gem "xcodeproj", :git => "https://github.com/CocoaPods/Xcodeproj.git", :branch => "master"
 
-gem 'jazzy'
+gem 'jazzy',  :git => "https://github.com/orta/Jazzy.git", :branch => "rc"
 
 gem "docstat"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,22 @@
+GIT
+  remote: https://github.com/orta/Jazzy.git
+  revision: 18cbab9827482c46f4d23aaa162820dc3704d2d4
+  branch: rc
+  specs:
+    jazzy (0.7.3)
+      cocoapods (= 1.1.0.rc.3)
+      mustache (~> 0.99)
+      open4
+      redcarpet (~> 3.2)
+      rouge (~> 1.5)
+      sass (~> 3.4)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
+    activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -13,38 +28,39 @@ GEM
       parser (>= 2.2.0.pre.3, < 3.0)
     backports (3.6.3)
     bacon (1.2.0)
-    claide (1.0.0)
-    cocoapods (1.0.1)
-      activesupport (>= 4.0.2)
-      claide (>= 1.0.0, < 2.0)
-      cocoapods-core (= 1.0.1)
-      cocoapods-deintegrate (>= 1.0.0, < 2.0)
-      cocoapods-downloader (>= 1.0.0, < 2.0)
+    claide (1.0.1)
+    cocoapods (1.1.0.rc.3)
+      activesupport (>= 4.0.2, < 5)
+      claide (>= 1.0.1, < 2.0)
+      cocoapods-core (= 1.1.0.rc.3)
+      cocoapods-deintegrate (>= 1.0.1, < 2.0)
+      cocoapods-downloader (>= 1.1.1, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-stats (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.0.0, < 2.0)
-      cocoapods-try (>= 1.0.0, < 2.0)
+      cocoapods-trunk (= 1.1.0.beta.1)
+      cocoapods-try (>= 1.1.0, < 2.0)
       colored (~> 1.2)
       escape (~> 0.0.4)
-      fourflusher (~> 0.3.0)
-      molinillo (~> 0.4.5)
+      fourflusher (~> 2.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.5.1)
       nap (~> 1.0)
-      xcodeproj (>= 1.1.0, < 2.0)
-    cocoapods-core (1.0.1)
-      activesupport (>= 4.0.2)
+      xcodeproj (>= 1.3.2, < 2.0)
+    cocoapods-core (1.1.0.rc.3)
+      activesupport (>= 4.0.2, < 5)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
-    cocoapods-deintegrate (1.0.0)
-    cocoapods-downloader (1.0.0)
+    cocoapods-deintegrate (1.0.1)
+    cocoapods-downloader (1.1.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
     cocoapods-stats (1.0.0)
-    cocoapods-trunk (1.0.0)
+    cocoapods-trunk (1.1.0.beta.1)
       nap (>= 0.8, < 2.0)
       netrc (= 0.7.8)
-    cocoapods-try (1.0.0)
+    cocoapods-try (1.1.0)
     coderay (1.1.0)
     colored (1.2)
     docstat (1.0.4)
@@ -63,7 +79,7 @@ GEM
     foreman (0.75.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    fourflusher (0.3.2)
+    fourflusher (2.0.0)
     fuzzy_match (2.0.4)
     gh (0.13.2)
       addressable
@@ -72,21 +88,13 @@ GEM
       multi_json (~> 1.0)
       net-http-persistent (>= 2.7)
       net-http-pipeline
+    gh_inspector (1.0.2)
     highline (1.6.21)
     htmlcompressor (0.1.2)
     httparty (0.8.3)
       multi_json (~> 1.0)
       multi_xml
     i18n (0.7.0)
-    jazzy (0.7.0)
-      cocoapods (~> 1.0)
-      mustache (~> 0.99)
-      open4
-      redcarpet (~> 3.2)
-      rouge (~> 1.5)
-      sass (~> 3.4)
-      sqlite3 (~> 1.3)
-      xcinvoke (~> 0.2.1)
     json (1.8.3)
     launchy (2.4.2)
       addressable (~> 2.3)
@@ -95,12 +103,12 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
-    minitest (5.9.0)
+    minitest (5.9.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
       mocha (>= 0.13.0)
-    molinillo (0.4.5)
+    molinillo (0.5.1)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -167,7 +175,7 @@ GEM
       temple (~> 0.6.3)
       tilt (~> 1.3, >= 1.3.3)
     slop (3.6.0)
-    sqlite3 (1.3.11)
+    sqlite3 (1.3.12)
     temple (0.6.9)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -194,9 +202,9 @@ GEM
     websocket (1.2.1)
     xcinvoke (0.2.1)
       liferaft (~> 0.0.4)
-    xcodeproj (1.1.0)
+    xcodeproj (1.3.2)
       activesupport (>= 3)
-      claide (>= 1.0.0, < 2.0)
+      claide (>= 1.0.1, < 2.0)
       colored (~> 1.2)
 
 PLATFORMS
@@ -204,15 +212,14 @@ PLATFORMS
 
 DEPENDENCIES
   bacon
-  cocoapods
-  cocoapods-core
+  cocoapods (= 1.1.0.rc.3)
   cocoapods-downloader
   colored (~> 1.2)
   docstat
   foreman
   htmlcompressor
   httparty
-  jazzy
+  jazzy!
   mocha
   mocha-on-bacon
   mustache
@@ -236,4 +243,4 @@ RUBY VERSION
    ruby 2.1.3p242
 
 BUNDLED WITH
-   1.12.5
+   1.13.2


### PR DESCRIPTION
Deprecates https://github.com/CocoaPods/cocoadocs.org/pull/468

Documents Pods relying on XC8 support properly now 👍 