### PR TITLE
Add support for custom README locations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "search.exclude": {
+     "**/activity/docsets": true,
+     "**/activity/carthage": true,   
+     "**/activity/cocoadocs_specs": true,
+      "**/activity/download": true,
+      "**/activity/logs": true,
+      "**/activity/readme": true,  
+      "**/activity/template": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ CocoaDocs is essentially 2 tools, one is a script for generating complex appledo
 
 CocoaDocs receives webhook notifications from the [CocoaPods/Specs](https://github.com/CocoaPods/Specs) repo on GitHub whenever a CocoaPod is updated.
 
-A Swift Pod will create documentation [using Jazzy](https://github.com/realm/jazzy/). If this fails, perhaps due to new Swift version support, than it will fall back to Objective-C.
-An *Objective-C* Pod will use Appledoc to parse your library.  
+A Swift Pod will create documentation [using Jazzy](https://github.com/realm/jazzy/). If this fails, perhaps due to new Swift version support, than it will fall back to Objective-C. An *Objective-C* Pod will use Appledoc to parse your library.  
+
+If you have a Swift library and it's only showing Objective-C classes (or no classes) then Jazzy has crashed on your library, we'd recommend testing that out locally.
 
 
 ##### What control do I have over CocoaDocs as a library author?
@@ -35,7 +36,8 @@ An *Objective-C* Pod will use Appledoc to parse your library.
    All defaults are stored in this config file for you to overwite.
 
  - You can find an example of styling at [ARAnalytics's .cocoadocs.yml](https://github.com/orta/ARAnalytics/blob/master/.cocoadocs.yml)
- - You can add your own documentation guides, either from remote markdown files or from files locally inside the library. CocoaDocs will automatically convert github wiki pages to the markdown behind it.
+ - You can change the location of your readme with `readme: path/to/README.md` in your `.cocoadocs.yml`.
+ - You can add your own documentation guides, either from remote markdown files or from files locally inside the library. CocoaDocs will automatically convert github wiki pages to the markdown behind it. These only work on Objective-C codebases.
 
    ```yaml
    additional_guides:

--- a/classes/readme_generator.rb
+++ b/classes/readme_generator.rb
@@ -2,7 +2,7 @@ class ReadmeGenerator
   POSSIBLE_CHANGELOG_NAMES = ['CHANGELOG', 'RELEASE_NOTES']
 
   include HashInit
-  attr_accessor :spec, :readme_location, :changelog_location, :active_folder
+  attr_accessor :spec, :readme_location, :changelog_location, :active_folder, :settings
 
   def create_changelog
     return if $skip_downloading_readme
@@ -17,7 +17,7 @@ class ReadmeGenerator
   def create_readme
     return if $skip_downloading_readme
 
-    spec_readme_path = file_local_path("README", @spec)
+    spec_readme_path = find_spec_readme_path(@settings, "README", @spec)
     spec_readme_path = generated_readme_path unless spec_readme_path
 
     markdown = github_render spec_readme_path, @readme_location
@@ -35,6 +35,13 @@ class ReadmeGenerator
     Octokit.client_id = '52019dadd0bc010084c4'
     Octokit.client_secret = 'c529632d7aa3ceffe3d93b589d8d2599ca7733e8'
     Octokit.markdown(File.read(spec_readme_path), mode: "markdown", context: context)
+  end
+
+  def find_spec_readme_path(settings, name, spec)
+    return file_local_path("README", @spec) unless settings.key? "readme"
+
+    readme_loc = settings["readme"]
+    return $active_folder + "/download/#{spec.name}/#{spec.version}/#{spec.name}/#{readme_loc}"
   end
 
   def file_local_path(name, spec)

--- a/cocoadocs.rb
+++ b/cocoadocs.rb
@@ -379,7 +379,7 @@ class CocoaDocs < Object
       settings = CocoaDocsSettings.settings_at_location download_location
       jazzy_config = CocoaDocsSettings.jazzy_config_at_location download_location
 
-      readme = ReadmeGenerator.new ({ :spec => spec, :readme_location => readme_location, :changelog_location => changelog_location })
+      readme = ReadmeGenerator.new ({ :spec => spec, :readme_location => readme_location, :changelog_location => changelog_location, :settings => settings })
       readme.create_readme
       readme.create_changelog
 


### PR DESCRIPTION
Allows a library to use a `.cocoadocs.yml` file to choose where a README should be rendered from. Fixes #500 

You would need a yaml file like this:

```yaml
readme: path/to/README.md
```