### PR TITLE
Update the URLs passed to CocoaPods about CD resources

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ begin
 
   def run_ssh_commands commands
     puts "Connecting to api.cocoadocs.org:"
-    Net::SSH.start('api.cocoadocs.org', 'cocoadocs') do |ssh|
+    Net::SSH.start('199.19.84.242', 'cocoadocs') do |ssh|
       ssh.shell do |sh|
         sh.execute 'cd cocoadocs.org'
         commands.each do |command|
@@ -25,7 +25,6 @@ begin
         sh.execute 'exit'
       end
     end
-
   end
 
   desc 'Starts the server via SSH'

--- a/classes/spec_extensions.rb
+++ b/classes/spec_extensions.rb
@@ -21,7 +21,7 @@ module Pod
     end
 
     def or_cocoadocs_url
-      "http://cocoadocs.org/docsets/#{ escaped_name }/#{ version }"
+      "https://s3.amazonaws.com/cocoadocs.org/docsets/#{ escaped_name }/#{ version }"
     end
 
     def or_git_ref

--- a/cocoapods-simple.rb
+++ b/cocoapods-simple.rb
@@ -27,10 +27,6 @@ $cocoadocs_specs_name = 'cocoadocs_specs'
 $active_folder = 'activity_pods'
 
 def run
-  specs_repo = 'CocoaPods/Specs'
-  s3_bucket = 'cocoadocs.org'
-  website_home = 'http://cocoadocs.org/'
-
   active_folder_name = $active_folder
   current_dir = File.dirname(File.expand_path(__FILE__))
   active_folder = File.join(current_dir, active_folder_name)


### PR DESCRIPTION
Rendered README/CHANGELOGs were going into the bucket right, but they were accessed via the cocoapods DNS which redirects to a different bucket without them.

<img width="936" alt="screen shot 2017-11-04 at 6 20 47 pm" src="https://user-images.githubusercontent.com/49038/32409963-ef469318-c18c-11e7-92a1-2bdc099e9d62.png">